### PR TITLE
fix error of touch point which lock size is (4,3)

### DIFF
--- a/CCGestureLock/Classes/CCGestureLock.swift
+++ b/CCGestureLock/Classes/CCGestureLock.swift
@@ -204,7 +204,7 @@ public class CCGestureLock: UIControl {
         if let previousSelection = selectionPath.last {
             
             let deltaIndex = abs(indexPath.item - previousSelection.item)
-            let deltaRows = abs(previousSelection.item/lockSize.numVerticalSensors - indexPath.item/lockSize.numVerticalSensors)
+            let deltaRows = abs(previousSelection.item/lockSize.numHorizontalSensors - indexPath.item/lockSize.numHorizontalSensors)
             let divisor = deltaRows > 1 && deltaIndex%deltaRows == 0 ? deltaIndex/deltaRows : deltaIndex
             updateSelectionPath(previousSelection.item, end: indexPath.item, increment: deltaRows == 0 ? 1 : divisor)
             


### PR DESCRIPTION
When lock size is not square, its touch point is weird.
In particular, when lock size is (4, 3), and I dragged from index 2 to index 6,  the touched point was 2, 4, 5, 6